### PR TITLE
Update Package for Laravel 11 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,15 +24,15 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2",
+        "php": "^8.1|^8.2|^8.3",
         "ext-bcmath": "*",
         "021/safely-transaction": "^1.0.1",
-        "laravel/framework": "^10.0"
+        "laravel/framework": "^v11.0.7"
     },
     "require-dev": {
         "larastan/larastan": "^2.0",
         "laravel/pint": "^1.13",
-        "orchestra/testbench": "^8.21",
+        "orchestra/testbench": "^v9.0.0",
         "phpunit/phpunit": "^10.5"
     },
     "autoload": {

--- a/database/migrations/create_transactions_table.php.stub
+++ b/database/migrations/create_transactions_table.php.stub
@@ -20,9 +20,10 @@ return new class extends Migration
             $table->id();
             $table->nullableMorphs('from');
             $table->nullableMorphs('to');
-            $table->unsignedDecimal('amount', 16, 8)->default(0)->index();
-            $table->unsignedDecimal('commission', 16, 8)->default(0);
-            $table->unsignedDecimal('received', 16, 8)
+            $table->decimal('amount', 16, 8)->unsigned()->default(0)->index();
+            $table->decimal('commission', 16, 8)->unsigned()->default(0);
+            $table->decimal('received', 16, 8)
+                ->unsigned()
                 ->default(0)
                 ->comment('received = amount - commission')
                 ->index();

--- a/tests/Concerns/BalanceSeed.php
+++ b/tests/Concerns/BalanceSeed.php
@@ -9,7 +9,6 @@ trait BalanceSeed
 {
     protected function createBalance(): array
     {
-        $this->refreshDatabase();
 
         /** @var \O21\LaravelWallet\Contracts\Payable $user */
         $user = User::factory()->create();


### PR DESCRIPTION
This pull request updates the package to be compatible with Laravel 11, alongside support for PHP 8.3. The changes ensure the package continues to work seamlessly with the latest Laravel framework version, improving its utility and extending its accessibility to applications on Laravel 11.

### Changes
- Updated `composer.json` to allow PHP versions up to 8.3 and set the Laravel framework version to `^v11.0.7`.
- Modified `create_transactions_table.php.stub` migration to use `decimal` instead of `unsignedDecimal` for columns `amount`, `commission`, and `received`. This change aligns with Laravel 11's database schema recommendations.
- Removed an unnecessary call to `refreshDatabase()` in `tests/Concerns/BalanceSeed.php`, streamlining the test setup.

### Impact
- **Compatibility**: Ensures compatibility with Laravel 11 and PHP 8.3.
- **Database Schema**: Aligns with Laravel 11's recommendations for decimal column definitions in migrations.
- **Testing**: Streamlines test setup by removing unnecessary database refresh calls.

These updates position the package to support the latest Laravel version, ensuring it remains a valuable tool for developers working with the framework's most recent release.

Please review the changes and merge them if they meet the project's standards and expectations.
